### PR TITLE
Remove 100 free hours

### DIFF
--- a/image-classification/README.md
+++ b/image-classification/README.md
@@ -1,6 +1,6 @@
 ## Running the Udacity Deep Learning Foundations image classification project on floydhub.com
 
-1. Create an account on [floydhub.com](https://www.floydhub.com) (don't forget to confirm your email). You will automatically receive 100 free GPU hours. 
+1. Create an account on [floydhub.com](https://www.floydhub.com) (don't forget to confirm your email).
 
 2. Install the `floyd` command on your computer:
 


### PR DESCRIPTION
Our 100 free GPU hours promotional period has ended. We are now working on a new pricing plan that should be out in the next couple of weeks. We still get a few requests from students that follow this guide :) It'd be great to remove the reference to the 100 free hours for now, till we have more info to add.